### PR TITLE
Add sematext_api_key param to provider {} block

### DIFF
--- a/generate/provider.go.template
+++ b/generate/provider.go.template
@@ -27,6 +27,19 @@ func Provider() *schema.Provider {
 	provider := &schema.Provider{
 
 		Schema: map[string]*schema.Schema{
+			"sematext_api_key": {
+				Type:        schema.TypeString,
+				Required:    false,
+				DefaultFunc: schema.EnvDefaultFunc("SEMATEXT_API_KEY", ""),
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					api_key := val.(string)
+					if val != nil && !sematext.IsValidUUID(api_key) {
+						errs = append(errs, fmt.Errorf("ERROR  : sematext_api_key invalid in sematext provider"))
+					}
+					return
+				},
+				Description: "Your Sematext API key, if not set using environment variable SEMATEXT_API_KEY.",
+			},
 			"sematext_region": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -133,11 +146,14 @@ func Provider() *schema.Provider {
 		}
 
 		token := os.Getenv("SEMATEXT_API_KEY")
+		if token == "" {
+		    	token = d.Get("sematext_api_key").(string)
+		}
 		if !sematext.IsValidUUID(token) {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
-				Summary:  "Missing or invalid env SEMATEXT_API_KEY",
-				Detail:   "Missing or invalid env SEMATEXT_API_KEY",
+				Summary:  "Missing or invalid env SEMATEXT_API_KEY or sematext_api_key parameter in provider stanza",
+				Detail:   "Missing or invalid env SEMATEXT_API_KEY or sematext_api_key parameter in provider stanza",
 			})
 
 			return nil, diags

--- a/generate/provider_index.md.template
+++ b/generate/provider_index.md.template
@@ -49,7 +49,7 @@ There are two authentication tokens
 The following environment variables are required:
 
 * SEMATEXT_REGION="US"
-* SEMATEXT_API_KEY="&lt;Sematext-Cloud-Token&gt;"
+* SEMATEXT_API_KEY="&lt;Sematext-Cloud-Token&gt;" # If not set using sematext_api_key in the `provider {}` code block
 
 If working with AWS Cloudwatch the following environment vars should be set:
 

--- a/generate/provider_index.md.template
+++ b/generate/provider_index.md.template
@@ -44,7 +44,7 @@ There are two authentication tokens
 * Sematext Cloud App access token - retrieved on resource creation - refer to examples on how to access this inside your Terrform scripting.
 
 
-## Enviropnment Variables
+## Environment Variables
 
 The following environment variables are required:
 

--- a/generate/provider_index.md.template
+++ b/generate/provider_index.md.template
@@ -18,7 +18,8 @@ terraform {
 }
 
 provider "sematext" {
-    sematext_region = "US"
+    sematext_api_key = "00000000-0000-0000-0000-000000000000"
+    sematext_region  = "US"
 }
 
 resource "sematext_monitor_nodejs" "mymonitor" {
@@ -31,6 +32,7 @@ resource "sematext_monitor_nodejs" "mymonitor" {
 
 The following arguments are supported:
 
+* `sematext_api_key` - (Optional) your Sematext Cloud API key. The provider will use environment variable SEMATEXT_API_KEY (see below) by default if both are set;
 * `sematext_region` - (Required) desired Sematext Cloud Region  "US" or "EU";
 
 


### PR DESCRIPTION
This is related to https://github.com/sematext/terraform-provider-sematext/issues/55

This PR adds a new `sematext_api_key` to the `provider {}` block to enable using API keys retrieved from external sources such as key vaults, variables, files, or (unrecommended) hard-coded values.

It still uses the ENV variable SEMATEXT_API_KEY by default, which if left blank will use the new new `sematext_api_key` provider parameter. I did not update the resource docs template to include the new `sematext_api_key` parameter in the example `provider {}` blocks because it might promote people saving credentials to their source code without sufficient warning about safety surrounding protecting credentials.